### PR TITLE
mpd: fix audio stuttering

### DIFF
--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -115,7 +115,6 @@ class Mpd < Formula
         <key>ProgramArguments</key>
         <array>
             <string>#{opt_bin}/mpd</string>
-            <string>--no-daemon</string>
         </array>
         <key>RunAtLoad</key>
         <true/>


### PR DESCRIPTION
mpd audio stutters when run under launchd if provided the --no-daemon flag, as described at http://apple.stackexchange.com/questions/180410/mpd-stuttering-when-run-under-launchd.  So let's not use that flag in the plist.
